### PR TITLE
Add writing workspace with autosave and streak tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
         <header class="text-center mb-8">
             <h1 class="text-5xl font-black text-gray-900 dark:text-gray-100">Run & Write</h1>
             <p class="text-lg text-gray-600 mt-2 dark:text-gray-400">Your Daily Dose of Creative Inspiration</p>
+            <p id="streakCounter" class="mt-3 inline-flex items-center justify-center px-4 py-1 text-sm font-semibold text-orange-600 bg-orange-100 rounded-full dark:text-orange-300 dark:bg-gray-800">🔥 Writing streak: 0 days</p>
         </header>
 
         <main class="w-full max-w-2xl bg-white rounded-xl shadow-lg p-8 border border-gray-200 dark:bg-gray-800 dark:border-gray-700">
@@ -64,6 +65,56 @@
                     <p id="promptText" class="text-lg text-gray-700 leading-relaxed dark:text-gray-300">Summoning a new prophecy from the ether...</p>
                 </div>
                 <div id="errorDisplay" class="hidden mt-4 text-red-600 bg-red-100 p-3 rounded-md dark:text-red-300 dark:bg-red-900"></div>
+            </div>
+            <button id="writeToggleBtn" class="mt-8 w-full flex items-center justify-between bg-orange-500 hover:bg-orange-600 text-white font-semibold py-3 px-4 rounded-lg shadow transition-transform focus:outline-none focus:ring-4 focus:ring-orange-200 dark:focus:ring-orange-800" aria-expanded="false" aria-controls="writePanel">
+                <span>Write Now</span>
+                <svg id="writeToggleIcon" class="w-5 h-5 transition-transform transform" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"></path>
+                </svg>
+            </button>
+            <div id="writePanel" class="hidden mt-4 space-y-6 bg-orange-50 rounded-lg border border-orange-200 p-4 dark:bg-gray-700 dark:border-gray-600">
+                <div>
+                    <label for="writingArea" class="block text-sm font-semibold text-gray-700 mb-2 dark:text-gray-200">Draft your response</label>
+                    <textarea id="writingArea" rows="8" class="w-full p-3 border border-orange-200 rounded-md focus:ring-2 focus:ring-orange-400 focus:border-orange-400 resize-none dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100" placeholder="Let the words flow..."></textarea>
+                </div>
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <p class="text-sm font-medium text-gray-700 dark:text-gray-200">Word count: <span id="wordCount" class="font-semibold">0</span></p>
+                    <p id="goalStatus" class="text-sm text-gray-600 dark:text-gray-300">Set a daily goal to track your streak.</p>
+                </div>
+                <div class="bg-white rounded-md border border-orange-200 p-4 shadow-sm dark:bg-gray-800 dark:border-gray-600">
+                    <h3 class="text-base font-semibold text-gray-800 dark:text-gray-100">Daily word goal</h3>
+                    <p class="text-sm text-gray-600 mt-1 dark:text-gray-300">Choose a target to unlock the streak counter.</p>
+                    <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+                        <input id="dailyWordGoal" type="number" min="0" class="w-full sm:w-40 p-2 border border-orange-200 rounded-md focus:ring-2 focus:ring-orange-400 focus:border-orange-400 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100" placeholder="e.g. 500">
+                        <button id="saveGoalBtn" class="w-full sm:w-auto bg-orange-500 text-white font-semibold py-2 px-4 rounded-md hover:bg-orange-600 transition focus:outline-none focus:ring-2 focus:ring-orange-300 dark:focus:ring-orange-700">Save goal</button>
+                    </div>
+                </div>
+                <div class="bg-white rounded-md border border-orange-200 p-4 shadow-sm dark:bg-gray-800 dark:border-gray-600">
+                    <h3 class="text-base font-semibold text-gray-800 dark:text-gray-100">Timed sprint</h3>
+                    <p class="text-sm text-gray-600 mt-1 dark:text-gray-300">Pick a duration and race the clock.</p>
+                    <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+                        <select id="sprintDuration" class="w-full sm:w-40 p-2 border border-orange-200 rounded-md focus:ring-2 focus:ring-orange-400 focus:border-orange-400 dark:bg-gray-900 dark:border-gray-700 dark:text-gray-100">
+                            <option value="5">5 minutes</option>
+                            <option value="10">10 minutes</option>
+                            <option value="15">15 minutes</option>
+                            <option value="20">20 minutes</option>
+                        </select>
+                        <div class="flex gap-2">
+                            <button id="startSprintBtn" class="flex-1 bg-gray-800 text-white font-semibold py-2 px-4 rounded-md hover:bg-gray-900 transition focus:outline-none focus:ring-2 focus:ring-gray-400 dark:bg-orange-500 dark:hover:bg-orange-600 dark:focus:ring-orange-700">Start sprint</button>
+                            <button id="stopSprintBtn" class="flex-1 bg-gray-200 text-gray-700 font-semibold py-2 px-4 rounded-md hover:bg-gray-300 transition focus:outline-none focus:ring-2 focus:ring-gray-300 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600" disabled>Stop</button>
+                        </div>
+                    </div>
+                    <p id="sprintStatus" class="text-sm text-gray-600 mt-2 dark:text-gray-300">Ready when you are.</p>
+                </div>
+                <div>
+                    <h3 class="text-base font-semibold text-gray-800 dark:text-gray-100">Export &amp; Share</h3>
+                    <p class="text-sm text-gray-600 mt-1 dark:text-gray-300">Wrap up by copying or downloading your draft.</p>
+                    <div class="mt-3 flex flex-col sm:flex-row gap-2">
+                        <button id="copyButton" class="w-full sm:w-auto bg-gray-800 text-white font-semibold py-2 px-4 rounded-md hover:bg-gray-900 transition focus:outline-none focus:ring-2 focus:ring-gray-400 dark:bg-orange-500 dark:hover:bg-orange-600 dark:focus:ring-orange-700">Copy to clipboard</button>
+                        <button id="downloadButton" class="w-full sm:w-auto bg-white text-gray-800 font-semibold py-2 px-4 rounded-md border border-gray-300 hover:bg-gray-50 transition focus:outline-none focus:ring-2 focus:ring-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:border-gray-600 dark:hover:bg-gray-700">Download .txt</button>
+                    </div>
+                    <p id="exportStatus" class="text-sm text-gray-600 mt-2 dark:text-gray-300"></p>
+                </div>
             </div>
              <div class="text-center mt-6">
                 <button id="historyBtn" class="bg-gray-700 hover:bg-gray-900 text-white font-bold py-2 px-6 rounded-lg transition-transform transform hover:scale-105 focus:outline-none focus:ring-4 focus:ring-gray-300 dark:bg-orange-600 dark:hover:bg-orange-700 dark:focus:ring-orange-800">
@@ -113,6 +164,346 @@
         const sunIcon = document.getElementById('themeIconSun');
         const moonIcon = document.getElementById('themeIconMoon');
 
+        // Writing workspace elements
+        const writeToggleBtn = document.getElementById('writeToggleBtn');
+        const writeToggleIcon = document.getElementById('writeToggleIcon');
+        const writePanel = document.getElementById('writePanel');
+        const writingArea = document.getElementById('writingArea');
+        const wordCountDisplay = document.getElementById('wordCount');
+        const goalStatus = document.getElementById('goalStatus');
+        const goalInput = document.getElementById('dailyWordGoal');
+        const saveGoalBtn = document.getElementById('saveGoalBtn');
+        const streakCounter = document.getElementById('streakCounter');
+        const sprintDuration = document.getElementById('sprintDuration');
+        const startSprintBtn = document.getElementById('startSprintBtn');
+        const stopSprintBtn = document.getElementById('stopSprintBtn');
+        const sprintStatus = document.getElementById('sprintStatus');
+        const exportStatus = document.getElementById('exportStatus');
+        const copyButton = document.getElementById('copyButton');
+        const downloadButton = document.getElementById('downloadButton');
+
+        let dailyGoal = 0;
+        let goalRecordedToday = false;
+        let sprintIntervalId = null;
+        let sprintEndTime = null;
+
+
+        function toggleWritePanel(forceOpen = null) {
+            if (!writePanel || !writeToggleBtn || !writeToggleIcon) return;
+            const isHidden = writePanel.classList.contains('hidden');
+            const shouldOpen = forceOpen === null ? isHidden : forceOpen;
+
+            if (shouldOpen) {
+                writePanel.classList.remove('hidden');
+                writeToggleBtn.setAttribute('aria-expanded', 'true');
+                writeToggleIcon.classList.add('rotate-180');
+            } else {
+                writePanel.classList.add('hidden');
+                writeToggleBtn.setAttribute('aria-expanded', 'false');
+                writeToggleIcon.classList.remove('rotate-180');
+            }
+        }
+
+        function getLocalDateKey(date = new Date()) {
+            const year = date.getFullYear();
+            const month = String(date.getMonth() + 1).padStart(2, '0');
+            const day = String(date.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
+        }
+
+        function getDraftStorageKey(dateKey = getLocalDateKey()) {
+            return `draft-${dateKey}`;
+        }
+
+        function loadDailyGoal() {
+            try {
+                const stored = localStorage.getItem('dailyWordGoal');
+                if (stored === null) {
+                    return 0;
+                }
+                const parsed = parseInt(stored, 10);
+                return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+            } catch (error) {
+                console.error('Failed to load daily goal', error);
+                return 0;
+            }
+        }
+
+        function persistDailyGoal(value) {
+            try {
+                if (value > 0) {
+                    localStorage.setItem('dailyWordGoal', String(value));
+                } else {
+                    localStorage.removeItem('dailyWordGoal');
+                }
+            } catch (error) {
+                console.error('Failed to persist daily goal', error);
+            }
+        }
+
+        function getWordCount(text) {
+            if (!text) return 0;
+            const trimmed = text.trim();
+            if (!trimmed) return 0;
+            return trimmed.split(/\s+/).length;
+        }
+
+        function saveDraft(text) {
+            try {
+                localStorage.setItem(getDraftStorageKey(), text);
+            } catch (error) {
+                console.error('Failed to save draft', error);
+            }
+        }
+
+        function restoreDraft() {
+            if (!writingArea) return;
+            try {
+                const saved = localStorage.getItem(getDraftStorageKey());
+                if (typeof saved === 'string') {
+                    writingArea.value = saved;
+                }
+            } catch (error) {
+                console.error('Failed to restore draft', error);
+            }
+        }
+
+        function loadCompletions() {
+            try {
+                const stored = localStorage.getItem('writingCompletions');
+                return stored ? JSON.parse(stored) : {};
+            } catch (error) {
+                console.error('Failed to parse completion history', error);
+                return {};
+            }
+        }
+
+        function saveCompletions(completions) {
+            try {
+                localStorage.setItem('writingCompletions', JSON.stringify(completions));
+            } catch (error) {
+                console.error('Failed to save completion history', error);
+            }
+        }
+
+        function markGoalComplete() {
+            goalRecordedToday = true;
+            const todayKey = getLocalDateKey();
+            const completions = loadCompletions();
+            if (!completions[todayKey] || !completions[todayKey].goalMet) {
+                completions[todayKey] = { goalMet: true, completedAt: Date.now() };
+                saveCompletions(completions);
+            }
+            updateStreakDisplay();
+        }
+
+        function updateStreakDisplay() {
+            if (!streakCounter) return;
+            const completions = loadCompletions();
+            let streak = 0;
+            const cursor = new Date();
+
+            while (true) {
+                const key = getLocalDateKey(cursor);
+                if (completions[key] && completions[key].goalMet) {
+                    streak += 1;
+                    cursor.setDate(cursor.getDate() - 1);
+                } else {
+                    break;
+                }
+            }
+
+            const label = `🔥 Writing streak: ${streak} day${streak === 1 ? '' : 's'}`;
+            streakCounter.textContent = label;
+        }
+
+        function updateGoalStatus(currentCount = getWordCount(writingArea ? writingArea.value : '')) {
+            if (!goalStatus) return;
+
+            if (!dailyGoal || dailyGoal <= 0) {
+                goalStatus.textContent = 'No daily goal set. Set one to start a streak.';
+                goalStatus.classList.remove('text-green-600', 'dark:text-green-400');
+                return;
+            }
+
+            const progressText = `${currentCount} / ${dailyGoal} words`;
+            if (goalRecordedToday) {
+                goalStatus.textContent = `Goal met! ${progressText}.`;
+                goalStatus.classList.add('text-green-600', 'dark:text-green-400');
+                return;
+            }
+
+            if (currentCount >= dailyGoal) {
+                markGoalComplete();
+                goalStatus.textContent = `Goal met! ${progressText}.`;
+                goalStatus.classList.add('text-green-600', 'dark:text-green-400');
+            } else {
+                goalStatus.textContent = `Keep going: ${progressText}.`;
+                goalStatus.classList.remove('text-green-600', 'dark:text-green-400');
+            }
+        }
+
+        function updateWordCount() {
+            if (!writingArea || !wordCountDisplay) return 0;
+            const text = writingArea.value;
+            const count = getWordCount(text);
+            wordCountDisplay.textContent = count;
+            updateGoalStatus(count);
+            return count;
+        }
+
+        function initializeGoalState() {
+            dailyGoal = loadDailyGoal();
+            if (goalInput) {
+                if (dailyGoal > 0) {
+                    goalInput.value = dailyGoal;
+                } else {
+                    goalInput.value = '';
+                }
+            }
+
+            const completions = loadCompletions();
+            goalRecordedToday = Boolean(completions[getLocalDateKey()]?.goalMet);
+
+            restoreDraft();
+            const count = updateWordCount();
+            updateStreakDisplay();
+
+            if (writingArea && writingArea.value.trim().length > 0) {
+                toggleWritePanel(true);
+            }
+
+            if (goalRecordedToday && dailyGoal > 0) {
+                goalStatus.textContent = `Goal met! ${count} / ${dailyGoal} words.`;
+                goalStatus.classList.add('text-green-600', 'dark:text-green-400');
+            }
+        }
+
+        function handleDraftInput() {
+            if (!writingArea) return;
+            saveDraft(writingArea.value);
+            updateWordCount();
+        }
+
+        function setDailyGoalFromInput() {
+            if (!goalInput) return;
+            const rawValue = parseInt(goalInput.value, 10);
+            const currentCount = getWordCount(writingArea ? writingArea.value : '');
+            const todayKey = getLocalDateKey();
+            const completions = loadCompletions();
+
+            if (Number.isFinite(rawValue) && rawValue > 0) {
+                dailyGoal = rawValue;
+                persistDailyGoal(dailyGoal);
+                goalRecordedToday = currentCount >= dailyGoal;
+                if (goalRecordedToday) {
+                    markGoalComplete();
+                } else if (completions[todayKey]) {
+                    delete completions[todayKey];
+                    saveCompletions(completions);
+                    updateStreakDisplay();
+                }
+            } else {
+                dailyGoal = 0;
+                persistDailyGoal(0);
+                goalRecordedToday = false;
+            }
+            updateGoalStatus(currentCount);
+        }
+
+        function startSprint() {
+            if (!sprintDuration || !startSprintBtn || !stopSprintBtn || !sprintStatus) return;
+            const minutes = parseInt(sprintDuration.value, 10);
+            if (!Number.isFinite(minutes) || minutes <= 0) {
+                sprintStatus.textContent = 'Choose how long you want to sprint before starting.';
+                return;
+            }
+
+            sprintEndTime = Date.now() + minutes * 60 * 1000;
+            updateSprintCountdown();
+            if (sprintIntervalId) {
+                clearInterval(sprintIntervalId);
+            }
+            sprintIntervalId = setInterval(updateSprintCountdown, 1000);
+
+            startSprintBtn.disabled = true;
+            stopSprintBtn.disabled = false;
+            sprintDuration.disabled = true;
+        }
+
+        function stopSprint(manual = true) {
+            if (!startSprintBtn || !stopSprintBtn || !sprintDuration || !sprintStatus) return;
+            if (sprintIntervalId) {
+                clearInterval(sprintIntervalId);
+                sprintIntervalId = null;
+            }
+            sprintEndTime = null;
+
+            startSprintBtn.disabled = false;
+            stopSprintBtn.disabled = true;
+            sprintDuration.disabled = false;
+
+            if (manual) {
+                sprintStatus.textContent = 'Sprint paused. Restart when ready.';
+            }
+        }
+
+        function updateSprintCountdown() {
+            if (!sprintStatus) return;
+            if (!sprintEndTime) return;
+
+            const remaining = sprintEndTime - Date.now();
+            if (remaining <= 0) {
+                sprintStatus.textContent = 'Sprint complete! Fantastic work.';
+                stopSprint(false);
+                return;
+            }
+
+            const minutes = Math.floor(remaining / 60000);
+            const seconds = Math.floor((remaining % 60000) / 1000);
+            sprintStatus.textContent = `Time remaining: ${minutes}:${String(seconds).padStart(2, '0')}`;
+        }
+
+        async function copyDraft() {
+            if (!writingArea || !exportStatus) return;
+            const text = writingArea.value;
+            if (!text) {
+                exportStatus.textContent = 'Nothing to copy yet. Draft a few lines first.';
+                return;
+            }
+
+            try {
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    await navigator.clipboard.writeText(text);
+                    exportStatus.textContent = 'Draft copied to your clipboard!';
+                } else {
+                    throw new Error('Clipboard API unavailable');
+                }
+            } catch (error) {
+                console.error('Copy failed', error);
+                exportStatus.textContent = 'Copy failed. Please select the text and copy manually.';
+            }
+        }
+
+        function downloadDraft() {
+            if (!writingArea || !exportStatus) return;
+            const text = writingArea.value;
+            if (!text) {
+                exportStatus.textContent = 'Nothing to download yet. Draft a few lines first.';
+                return;
+            }
+
+            const blob = new Blob([text], { type: 'text/plain' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `run-write-${getLocalDateKey()}.txt`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+            exportStatus.textContent = 'Download ready! Check your files for the new .txt.';
+        }
 
         // --- This is the original, working prompt-fetching logic ---
         async function getPrompt() {
@@ -220,6 +611,36 @@
         }
 
         // --- Event Listeners for all functionality ---
+        if (writeToggleBtn) {
+            writeToggleBtn.addEventListener('click', () => toggleWritePanel());
+        }
+        if (writingArea) {
+            writingArea.addEventListener('input', handleDraftInput);
+        }
+        if (saveGoalBtn) {
+            saveGoalBtn.addEventListener('click', setDailyGoalFromInput);
+        }
+        if (goalInput) {
+            goalInput.addEventListener('keydown', (event) => {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    setDailyGoalFromInput();
+                }
+            });
+        }
+        if (startSprintBtn) {
+            startSprintBtn.addEventListener('click', startSprint);
+        }
+        if (stopSprintBtn) {
+            stopSprintBtn.addEventListener('click', () => stopSprint(true));
+        }
+        if (copyButton) {
+            copyButton.addEventListener('click', copyDraft);
+        }
+        if (downloadButton) {
+            downloadButton.addEventListener('click', downloadDraft);
+        }
+
         historyBtn.addEventListener('click', getHistory);
         closeHistoryBtn.addEventListener('click', closeHistoryModal);
         historyModal.addEventListener('click', (event) => {
@@ -232,6 +653,7 @@
         document.addEventListener('DOMContentLoaded', () => {
             getPrompt();
             syncThemeUI(); // We sync the theme icon on page load
+            initializeGoalState();
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add a collapsible "Write Now" workspace with drafting tools, word goal management, timed sprints, and export actions
- persist drafts and completion metadata in localStorage to restore writing sessions and drive the homepage streak counter

## Testing
- no tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ccbd4b6398832a9c7f0c05a2b90950