### PR TITLE
Add homepage link to main Run & Write site

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,14 @@
         <header class="text-center mb-8">
             <h1 class="text-5xl font-black text-gray-900 dark:text-gray-100">Run & Write</h1>
             <p class="text-lg text-gray-600 mt-2 dark:text-gray-400">Your Daily Dose of Creative Inspiration</p>
+            <div class="mt-4">
+                <a href="https://www.run-write.com" class="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-orange-500 rounded-lg shadow hover:bg-orange-600 focus:outline-none focus:ring-4 focus:ring-orange-200 dark:bg-orange-600 dark:hover:bg-orange-700 dark:focus:ring-orange-800">
+                    Visit run-write.com
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M14 3h7v7m0-7L10 14m0 0H3m7 0v7"></path>
+                    </svg>
+                </a>
+            </div>
             <p id="streakCounter" class="mt-3 inline-flex items-center justify-center px-4 py-1 text-sm font-semibold text-orange-600 bg-orange-100 rounded-full dark:text-orange-300 dark:bg-gray-800">🔥 Writing streak: 0 days</p>
         </header>
 


### PR DESCRIPTION
## Summary
- add a prominent call-to-action link on the homepage header that directs visitors to https://www.run-write.com

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cccba2dc5c832aa073772cbc1d0410