### PR TITLE
Replace Gemini API with Claude for prompt generation

### DIFF
--- a/app/api/admin/seed-prompt/route.js
+++ b/app/api/admin/seed-prompt/route.js
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { isAdmin } from '@/lib/admin';
+import Anthropic from '@anthropic-ai/sdk';
 
 export async function POST(request) {
     // 1. Auth Check
@@ -19,13 +20,13 @@ export async function POST(request) {
             return NextResponse.json({ message: 'Date and Theme are required' }, { status: 400 });
         }
 
-        // 2. Generate via Gemini
-        const apiKey = process.env.GEMINI_API_KEY;
+        // 2. Generate via Claude
+        const apiKey = process.env.ANTHROPIC_API_KEY;
         if (!apiKey) {
-            return NextResponse.json({ message: 'Gemini API Key missing' }, { status: 500 });
+            return NextResponse.json({ message: 'Anthropic API Key missing' }, { status: 500 });
         }
 
-        const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent`;
+        const anthropic = new Anthropic({ apiKey });
 
         const promptInstruction = `Generate a unique and creative writing prompt for a creative writer.
         The specific theme/topic requested is: ${theme}.
@@ -38,30 +39,24 @@ export async function POST(request) {
         - It should only be 1-2 sentences.
         - Do not return formatting (no markdown, no bold text).`;
 
-        const payload = {
-            contents: [{ parts: [{ text: promptInstruction }] }],
-            generationConfig: {
-                temperature: 1.0 // High creativity
-            }
-        };
-
-        const geminiResponse = await fetch(apiUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
-            body: JSON.stringify(payload)
-        });
-
-        if (!geminiResponse.ok) {
-            const error = await geminiResponse.json();
-            console.error("Gemini API Error (Seeding):", error);
-            return NextResponse.json({ message: 'Failed to generate prompt from Gemini' }, { status: 502 });
+        let claudeResponse;
+        try {
+            claudeResponse = await anthropic.messages.create({
+                model: 'claude-sonnet-4-6',
+                max_tokens: 256,
+                messages: [{ role: 'user', content: promptInstruction }],
+            });
+        } catch (apiError) {
+            console.error("Claude API Error (Seeding):", apiError);
+            return NextResponse.json({ message: 'Failed to generate prompt from Claude' }, { status: 502 });
         }
 
-        const result = await geminiResponse.json();
-        const newPromptText = result.candidates?.[0]?.content?.parts?.[0]?.text;
+        const newPromptText = claudeResponse.content?.[0]?.type === 'text'
+            ? claudeResponse.content[0].text
+            : null;
 
         if (!newPromptText) {
-             return NextResponse.json({ message: 'Gemini returned empty response' }, { status: 502 });
+            return NextResponse.json({ message: 'Claude returned empty response' }, { status: 502 });
         }
 
         // 3. Save to DB (Upsert)

--- a/app/api/get-prompt/route.js
+++ b/app/api/get-prompt/route.js
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import Anthropic from '@anthropic-ai/sdk';
 
 function getEasterDate(year) {
     const f = Math.floor,
@@ -91,18 +92,16 @@ export async function POST(request) {
                 // Continue to generate. If DB is down/uninitialized, we can still try to generate and just return the text without saving.
             }
 
-            // 2. Generate via Gemini
-            const apiKey = process.env.GEMINI_API_KEY;
+            // 2. Generate via Claude
+            const apiKey = process.env.ANTHROPIC_API_KEY;
             if (!apiKey) {
-                console.error("Missing GEMINI_API_KEY");
-                // Fallback prompt if API key is missing
+                console.error("Missing ANTHROPIC_API_KEY");
                 return NextResponse.json({
                     text: "The oracle is sleeping (API Key missing). Please check your configuration. In the meantime: Describe a character realizing they have been wrong about something important for their entire life."
                 });
             }
 
-            // Using the user-specified model: gemini-2.0-flash
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent`;
+            const anthropic = new Anthropic({ apiKey });
 
             const themes = [
                 "Mystery", "Sci-Fi", "Nature", "Emotional", "Urban",
@@ -127,29 +126,23 @@ export async function POST(request) {
             - VARIETY: Focus on present action or an immediate situation.
             - Do not return formatting (no markdown, no bold text).`;
 
-            const payload = {
-                contents: [{ parts: [{ text: finalPrompt }] }],
-                generationConfig: {
-                    temperature: 1.0
-                }
-            };
-
-            const geminiResponse = await fetch(apiUrl, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey },
-                body: JSON.stringify(payload)
-            });
-
-            if (!geminiResponse.ok) {
-                const error = await geminiResponse.json();
-                console.error("Gemini API Error:", error);
+            let claudeResponse;
+            try {
+                claudeResponse = await anthropic.messages.create({
+                    model: 'claude-sonnet-4-6',
+                    max_tokens: 256,
+                    messages: [{ role: 'user', content: finalPrompt }],
+                });
+            } catch (apiError) {
+                console.error("Claude API Error:", apiError);
                 return NextResponse.json({
-                    text: "The stars are misaligned (Gemini API Error). Please try again later. In the meantime: Write about a silence that speaks louder than words."
+                    text: "The stars are misaligned (Claude API Error). Please try again later. In the meantime: Write about a silence that speaks louder than words."
                 });
             }
 
-            const result = await geminiResponse.json();
-            const newPromptText = result.candidates?.[0]?.content?.parts?.[0]?.text;
+            const newPromptText = claudeResponse.content?.[0]?.type === 'text'
+                ? claudeResponse.content[0].text
+                : null;
 
             if (newPromptText) {
                 // 3. Try to save to DB

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "run-write",
       "version": "1.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
         "@auth/prisma-adapter": "^2.11.1",
         "@prisma/client": "^5.11.0",
         "@tailwindcss/postcss": "^4.1.17",
@@ -46,12 +47,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@auth/core": {
       "version": "0.34.3",
       "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.34.3.tgz",
       "integrity": "sha512-jMjY/S0doZnWYNV90x0jmU3B+UcrsfGYnukxYrRbj0CVvGI/MX3JbHsxSrx2d4mbnXaUsqJmAcDfoQWA6r0lOw==",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@panva/hkdf": "^1.1.1",
         "@types/cookie": "0.6.0",
@@ -84,6 +106,7 @@
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -94,8 +117,21 @@
       "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@auth/core/node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@auth/core/node_modules/preact-render-to-string": {
@@ -104,6 +140,7 @@
       "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "pretty-format": "^3.8.0"
       },
@@ -199,19 +236,30 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT",
       "optional": true
     },
@@ -875,7 +923,6 @@
       "integrity": "sha512-SWshvS5FDXvgJKM/a0y9nDC1rqd7KG0Q6ZVzd+U7ZXK5soe73DJxJJgbNBt2GNXOa+ysWB4suTpdK5zfFPhwiw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=16.13"
       },
@@ -1227,7 +1274,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.11.0.tgz",
       "integrity": "sha512-kmS7ZVpHm1EMnW1Wmft9H5ZLM7E0G0NGBx+aGEHGDcNxZBXD2ZUa76CuWjIhOGpwsPbELp684ZdpF2JWoNi4Dg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1450,7 +1496,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.11.0.tgz",
       "integrity": "sha512-4Ane7VCVZ+GFOQNuy2nMP+SoWH7EemC3geTTqvgHm1H0tbSosxLJAVaZ9dF06F35RJmYCm+jLJUhRVd156eCRQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1569,7 +1614,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.11.0.tgz",
       "integrity": "sha512-g43beA73ZMLezez1st9LEwYrRHZ0FLzlsSlOZKk7sdmtHLmuqWHf4oyb0XAHol1HZIdGv104rYaGNgmQXr1ecQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1584,7 +1628,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.11.0.tgz",
       "integrity": "sha512-plCQDLCZIOc92cizB8NNhBRN0szvYR3cx9i5IXo6v9Xsgcun8KHNcJkesc2AyeqdIs0BtOJZaqQ9adHThz8UDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -1678,7 +1721,8 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -1844,7 +1888,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -1926,7 +1969,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -2131,6 +2175,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/lightningcss": {
@@ -2473,7 +2530,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.0.7.tgz",
       "integrity": "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.0.7",
         "@swc/helpers": "0.5.15",
@@ -2608,6 +2664,7 @@
       "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -2682,7 +2739,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2717,7 +2773,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2748,7 +2803,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.11.0"
       },
@@ -2871,7 +2925,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -2901,7 +2954,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -2950,7 +3002,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.3.tgz",
       "integrity": "sha512-SqMiYMUQNNBP9kfPhLO8WXEk/fon47vc52FQsUiJzTBuyjKgEcoAwMyF04eQ4WZ2ArMn7+ReypYL60aKngbACQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -2971,7 +3022,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2981,7 +3031,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3119,8 +3168,7 @@
       "version": "4.1.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.17.tgz",
       "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -3134,6 +3182,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.91.1",
     "@auth/prisma-adapter": "^2.11.1",
     "@prisma/client": "^5.11.0",
     "@tailwindcss/postcss": "^4.1.17",


### PR DESCRIPTION
## Summary
This PR migrates the prompt generation functionality from Google's Gemini API to Anthropic's Claude API across the application. The change affects both the admin seed prompt endpoint and the public prompt generation endpoint.

## Key Changes
- **API Migration**: Replaced Gemini API calls with Claude API using the `@anthropic-ai/sdk` package
  - Updated environment variable from `GEMINI_API_KEY` to `ANTHROPIC_API_KEY`
  - Changed API client initialization to use Anthropic SDK instead of direct HTTP requests
  - Updated model selection to `claude-sonnet-4-6`

- **Request/Response Handling**: Refactored API communication
  - Replaced Gemini's REST API payload structure with Anthropic SDK's `messages.create()` method
  - Updated response parsing to handle Claude's response format (`content[0].type === 'text'`)
  - Changed error handling from HTTP status checks to try-catch blocks for SDK exceptions

- **Files Modified**:
  - `app/api/admin/seed-prompt/route.js`: Updated admin endpoint for seeding prompts
  - `app/api/get-prompt/route.js`: Updated public endpoint for generating prompts
  - `package.json`: Added `@anthropic-ai/sdk` dependency

## Implementation Details
- Both endpoints now use the same Claude model (`claude-sonnet-4-6`) with `max_tokens: 256`
- Temperature parameter removed (Claude uses default settings; Gemini had `temperature: 1.0`)
- Error messages updated to reference Claude instead of Gemini
- Fallback error messages in the public endpoint updated to reflect the API change

https://claude.ai/code/session_01NXmFEA2WGEZ75V85gqRj4p