### PR TITLE
Fix navbar layout: add sticky nav, remove duplicate links

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -117,11 +117,22 @@ export default function Home() {
 
     return (
         <div className="min-h-screen flex flex-col">
-            {/* Top nav bar */}
-            <div className="w-full flex justify-between items-center px-4 pt-4 pb-0 max-w-2xl mx-auto">
-                <AuthButton />
-                <ThemeToggle />
-            </div>
+            {/* Sticky top navbar */}
+            <nav className="sticky top-0 z-40 w-full bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
+                <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between">
+                    <span className="font-black text-base text-gray-900 dark:text-white tracking-tight">Run & Write</span>
+                    <div className="flex items-center gap-1 sm:gap-3">
+                        <Link href="/community" className="px-3 py-1.5 text-sm font-semibold text-gray-600 hover:text-orange-500 dark:text-gray-300 dark:hover:text-orange-400 transition rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 hidden sm:block">
+                            Community
+                        </Link>
+                        <a href="https://www.run-write.com" className="px-3 py-1.5 text-sm font-semibold text-gray-600 hover:text-orange-500 dark:text-gray-300 dark:hover:text-orange-400 transition rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 hidden sm:block">
+                            About
+                        </a>
+                        <ThemeToggle />
+                        <AuthButton />
+                    </div>
+                </div>
+            </nav>
 
             {/* Page content */}
             <div className="flex-grow flex flex-col items-center px-4 pb-12">

--- a/components/AuthButton.js
+++ b/components/AuthButton.js
@@ -69,20 +69,12 @@ export default function AuthButton() {
   }
 
   return (
-    <div className="flex gap-3 items-center">
-        <Link
-            href="/community"
-            className="text-sm font-semibold text-gray-600 hover:text-orange-600 dark:text-gray-300 dark:hover:text-orange-400 hidden sm:block transition"
-        >
-            Community
-        </Link>
-        <button
-            onClick={() => signIn("google")}
-            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-orange-500 rounded-lg shadow hover:bg-orange-600 focus:outline-none focus:ring-4 focus:ring-orange-200 dark:focus:ring-orange-800 transition-transform transform hover:scale-105"
-        >
-            <LogIn size={18} />
-            Sign In
-        </button>
-    </div>
+    <button
+        onClick={() => signIn("google")}
+        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-orange-500 rounded-lg shadow hover:bg-orange-600 focus:outline-none focus:ring-4 focus:ring-orange-200 dark:focus:ring-orange-800 transition-transform transform hover:scale-105"
+    >
+        <LogIn size={16} />
+        Sign In
+    </button>
   );
 }

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,42 +1,9 @@
-import Link from 'next/link';
-import { useSession } from 'next-auth/react';
-
 export default function Header({ streak }) {
-    const { data: session } = useSession();
-
     return (
-        <header className="text-center mb-8">
-            <h1 className="text-5xl font-black text-gray-900 dark:text-gray-100 mt-8 sm:mt-0 tracking-tight">Run & Write</h1>
+        <header className="text-center mb-8 mt-10">
+            <h1 className="text-5xl font-black text-gray-900 dark:text-gray-100 tracking-tight">Run & Write</h1>
             <p className="text-lg text-gray-500 mt-2 dark:text-gray-400 italic">Where Writers Find Their Spark Daily</p>
-
-            {/* Navigation Links */}
-            <div className="mt-4 flex justify-center gap-3 flex-wrap">
-                <a
-                    href="https://www.run-write.com"
-                    className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-orange-500 rounded-lg shadow hover:bg-orange-600 focus:outline-none focus:ring-4 focus:ring-orange-200 dark:bg-orange-600 dark:hover:bg-orange-700 dark:focus:ring-orange-800 transition"
-                >
-                    About
-                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M14 3h7v7m0-7L10 14m0 0H3m7 0v7" />
-                    </svg>
-                </a>
-                <Link
-                    href="/community"
-                    className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-gray-700 bg-gray-200 rounded-lg shadow hover:bg-gray-300 focus:outline-none dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition"
-                >
-                    Community Feed
-                </Link>
-                {session?.user?.id && (
-                    <Link
-                        href={`/profile/${session.user.id}`}
-                        className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-gray-700 bg-gray-200 rounded-lg shadow hover:bg-gray-300 focus:outline-none dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600 transition"
-                    >
-                        My Profile
-                    </Link>
-                )}
-            </div>
-
-            <p id="streakCounter" className="mt-3 inline-flex items-center justify-center px-4 py-1 text-sm font-semibold text-orange-600 bg-orange-100 rounded-full dark:text-orange-300 dark:bg-gray-800">
+            <p id="streakCounter" className="mt-4 inline-flex items-center justify-center px-4 py-1.5 text-sm font-semibold text-orange-600 bg-orange-100 rounded-full dark:text-orange-300 dark:bg-gray-800">
                 🔥 Writing streak: {streak} {streak === 1 ? 'day' : 'days'}
             </p>
         </header>

--- a/components/ThemeToggle.js
+++ b/components/ThemeToggle.js
@@ -32,14 +32,12 @@ export default function ThemeToggle() {
   };
 
   return (
-    <div className="absolute top-4 right-4">
-      <button
-        onClick={toggleTheme}
-        className="p-2 rounded-full bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 transition focus:outline-none focus:ring-2 focus:ring-orange-500"
-        aria-label="Toggle Theme"
-      >
-        {theme === 'light' ? <Moon size={24} /> : <Sun size={24} />}
-      </button>
-    </div>
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600 transition focus:outline-none focus:ring-2 focus:ring-orange-500"
+      aria-label="Toggle Theme"
+    >
+      {theme === 'light' ? <Moon size={18} /> : <Sun size={18} />}
+    </button>
   );
 }


### PR DESCRIPTION
Replaces the awkward floating top bar with a proper sticky navbar that holds About, Community, ThemeToggle, and Sign In. Removes duplicate Community/About links from Header. Fixes ThemeToggle's absolute positioning so it sits inline in the nav.

https://claude.ai/code/session_01NXmFEA2WGEZ75V85gqRj4p